### PR TITLE
ログイン後の画面遷移

### DIFF
--- a/native/android/app/src/main/java/work/calmato/prestopay/MainActivity.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/MainActivity.kt
@@ -1,107 +1,12 @@
 package work.calmato.prestopay
 
-
-import android.annotation.SuppressLint
 import android.os.Bundle
-import android.preference.PreferenceManager
-import android.util.Log
-import android.view.View
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.navigation.findNavController
-import com.google.android.gms.tasks.OnCompleteListener
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.FirebaseUser
-import com.google.firebase.iid.FirebaseInstanceId
-import kotlinx.android.synthetic.main.fragment_login.*
-import work.calmato.prestopay.ui.login.LoginFragmentDirections
 
-class MainActivity : AppCompatActivity(), View.OnClickListener {
-  private lateinit var auth: FirebaseAuth
-  // [END declare_auth]
-
-
+class MainActivity : AppCompatActivity(){
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.fragment_login)
-    auth = FirebaseAuth.getInstance()
-
-    loginButton.setOnClickListener(this)
-    loginNewText.setOnClickListener(this)
-
-    val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
-    val value = sharedPreferences.getString("token", null)
-    Log.d(TAG, "token default: " + value)
+    setContentView(R.layout.activity_main)
   }
 
-  public override fun onStart() {
-    super.onStart()
-    // Check if user is signed in (non-null) and update UI accordingly.
-    val currentUser = auth.currentUser
-    updateUI(currentUser)
-  }
-
-  @SuppressLint("ShowToast")
-  private fun singInAccount(email: String, password: String) {
-    Log.d(TAG, "signInAccount:$email")
-    // [START create_user_with_email]
-    if (email != "" && password != "") {
-      FirebaseInstanceId.getInstance().instanceId
-        .addOnCompleteListener(OnCompleteListener { task ->
-      auth.signInWithEmailAndPassword(email, password)
-          if (task.isSuccessful) {
-            // Sign in success, update UI with the signed-in user's information
-            Log.d(TAG, "signInWithEmail:success")
-            val user = auth.currentUser
-            user?.getIdToken(true)?.addOnCompleteListener(this) { task ->
-              val idToken = task.getResult()?.token
-
-              val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
-              val editor = sharedPreferences.edit()
-              editor.putString("token", idToken)
-              editor.apply()
-            }
-            updateUI(user)
-          } else {
-            // If sign in fails, display a message to the user.
-            Log.w(TAG, "signInWithEmail:failure", task.exception)
-            Toast.makeText(
-              baseContext, "Authentication failed.",
-              Toast.LENGTH_SHORT
-            ).show()
-            updateUI(null)
-          }
-
-        })
-    } else {
-      Toast.makeText(baseContext, "email and password input", Toast.LENGTH_SHORT).show()
-    }
-    // [END create_user_with_email]
-  }
-
-  private fun updateUI(user: FirebaseUser?) {
-    if (user != null) {
-      //home pageの遷移
-      Log.d(TAG,user.email)
-      user.getIdToken(true)
-    } else {
-      Toast.makeText(baseContext, "Type it again", Toast.LENGTH_SHORT).show()
-    }
-  }
-
-  override fun onClick(v: View?) {
-    val i = v?.id
-    when (i) {
-      R.id.loginNewText -> findNavController(R.id.nav_host_fragment)
-        .navigate(LoginFragmentDirections.actionLoginFragmentToNewAccountFragment())
-      R.id.loginButton -> singInAccount(
-        loginEmailFileld.text.toString(),
-        loginPasswordField.text.toString()
-      )
-    }
-  }
-
-  companion object {
-    private const val TAG = "EmailPassword"
-  }
 }

--- a/native/android/app/src/main/java/work/calmato/prestopay/ui/login/LoginFragment.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/ui/login/LoginFragment.kt
@@ -1,10 +1,30 @@
 package work.calmato.prestopay.ui.login
 
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.preference.PreferenceManager
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.iid.FirebaseInstanceId
+import kotlinx.android.synthetic.main.fragment_login.*
+import work.calmato.prestopay.MainActivity
+import work.calmato.prestopay.R
+import work.calmato.prestopay.databinding.FragmentLoginBinding
+import work.calmato.prestopay.ui.newAccount.NewAccountFragmentDirections
 
 
 class LoginFragment : Fragment() {
-/*  override fun onCreateView(
+  private lateinit var auth: FirebaseAuth
+  override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
     savedInstanceState: Bundle?
@@ -13,14 +33,80 @@ class LoginFragment : Fragment() {
       inflater, R.layout.fragment_login, container, false
     )
     return binding.root
-  }*/
+  }
 
-  /*override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     loginNewText.setOnClickListener {
       this.findNavController().navigate(
         LoginFragmentDirections.actionLoginFragmentToNewAccountFragment()
       )
     }
-  }*/
+
+    loginButton.setOnClickListener {
+      singInAccount(
+        loginEmailFileld.text.toString(),
+        loginPasswordField.text.toString()
+      )
+    }
+    val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
+    val value = sharedPreferences.getString("token", null)
+    Log.d(TAG, "token default: " + value)
+    auth = FirebaseAuth.getInstance()
+  }
+    override fun onStart() {
+    super.onStart()
+    // Check if user is signed in (non-null) and update UI accordingly.
+    val currentUser = auth.currentUser
+    updateUI(currentUser)
+  }
+  @SuppressLint("ShowToast")
+  private fun singInAccount(email: String, password: String) {
+    Log.d(TAG, "signInAccount:$email")
+    // [START create_user_with_email]
+    if (email != "" && password != "") {
+      FirebaseInstanceId.getInstance().instanceId
+        .addOnCompleteListener(OnCompleteListener { task ->
+          auth.signInWithEmailAndPassword(email, password)
+          if (task.isSuccessful) {
+            // Sign in success, update UI with the signed-in user's information
+            Log.d(TAG, "signInWithEmail:success")
+            val user = auth.currentUser
+            user?.getIdToken(true)?.addOnCompleteListener(requireActivity()) { task ->
+              val idToken = task.getResult()?.token
+              val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+              val editor = sharedPreferences.edit()
+              editor.putString("token", idToken)
+              editor.apply()
+            }
+            updateUI(user)
+          } else {
+            // If sign in fails, display a message to the user.
+            Log.w(TAG, "signInWithEmail:failure", task.exception)
+            Toast.makeText(
+              requireContext(), "Authentication failed.",
+              Toast.LENGTH_SHORT
+            ).show()
+            Toast.makeText(requireContext(), "Type it again", Toast.LENGTH_SHORT).show()
+          }
+
+        })
+    } else {
+      Toast.makeText(requireContext(), "email and password input", Toast.LENGTH_SHORT).show()
+    }
+    // [END create_user_with_email]
+  }
+  private fun updateUI(user: FirebaseUser?) {
+    if (user != null) {
+      //home pageの遷移
+      Log.d(TAG,user.email)
+      user.getIdToken(true)
+      this.findNavController().navigate(
+        LoginFragmentDirections.actionLoginFragmentToHomeFragment()
+      )
+    }
+  }
+  companion object {
+    internal const val TAG = "EmailPassword"
+  }
 }


### PR DESCRIPTION


## やったこと

- ログイン後に画面遷移できるようにした。

- そのためにMainActivityに書かれていたログイン関連のコードをLoginFragmentに移植した。

### レビュー時のポイント

- ログイン機能と画面遷移の確認を念のためしてもらいたい。

- その後一度アプリを落としてから立ち上げるとログイン画面ではなくホーム画面が初期画面のはず。

## 残タスク

- Googleとかでログインできるように

- ログアウトできるようにする


## 備考

現段階では一度ログインすると次回以降の起動時にホーム画面に行ってしまうのでログインのテストできない。
その時は設定→アプリ→プレストペイ→ストレージの削除
で初期化できる！
