### PR TITLE
refactor: ユーザー情報取得APIのエンドポイントを分割

### DIFF
--- a/api/calc/internal/infrastructure/api/client.go
+++ b/api/calc/internal/infrastructure/api/client.go
@@ -78,7 +78,7 @@ func (c *Client) Authentication(ctx context.Context) (*user.User, error) {
 
 // ShowUser - ユーザー情報取得
 func (c *Client) ShowUser(ctx context.Context, userID string) (*user.User, error) {
-	url := c.userAPIURL + "/v1/users/" + userID
+	url := c.userAPIURL + "/internal/users/" + userID
 	req, _ := http.NewRequest("GET", url, nil)
 
 	if err := setHeader(ctx, req); err != nil {
@@ -110,7 +110,7 @@ func (c *Client) ShowUser(ctx context.Context, userID string) (*user.User, error
 
 // UserExists - ユーザーの存在性検証
 func (c *Client) UserExists(ctx context.Context, userID string) (bool, error) {
-	url := c.userAPIURL + "/v1/users/" + userID
+	url := c.userAPIURL + "/internal/users/" + userID
 	req, _ := http.NewRequest("GET", url, nil)
 
 	if err := setHeader(ctx, req); err != nil {

--- a/api/user/config/router.go
+++ b/api/user/config/router.go
@@ -47,6 +47,8 @@ func Router(reg *registry.Registry) *gin.Engine {
 	// internal routes
 	internal := r.Group("/internal")
 	{
+		internal.GET("/users/:userID", reg.V1User.ShowInternal)
+
 		internal.POST("/users/:userID/groups/:groupID", reg.V1User.AddGroup)
 		internal.DELETE("/users/:userID/groups/:groupID", reg.V1User.RemoveGroup)
 	}

--- a/api/user/internal/application/response/user.go
+++ b/api/user/internal/application/response/user.go
@@ -9,12 +9,24 @@ type IndexUsers struct {
 
 // ShowUser - ユーザー取得APIのレスポンス
 type ShowUser struct {
-	ID           string   `json:"id"`
-	Name         string   `json:"name"`
-	Username     string   `json:"username"`
-	Email        string   `json:"email"`
-	ThumbnailURL string   `json:"thumbnailUrl"`
-	GroupIDs     []string `json:"groupIds"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Username     string `json:"username"`
+	Email        string `json:"email"`
+	ThumbnailURL string `json:"thumbnailUrl"`
+}
+
+// ShowUserInternal - 内部向けユーザー取得APIのレスポンス
+type ShowUserInternal struct {
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	Username     string    `json:"username"`
+	Email        string    `json:"email"`
+	ThumbnailURL string    `json:"thumbnailUrl"`
+	GroupIDs     []string  `json:"groupIds"`
+	FriendIDs    []string  `json:"friendIds"`
+	CreatedAt    time.Time `json:"createdAt"`
+	UpdatedAt    time.Time `json:"updatedAt"`
 }
 
 // ShowProfile - ログインユーザー取得APIのレスポンス

--- a/api/user/internal/interface/handler/v1/user.go
+++ b/api/user/internal/interface/handler/v1/user.go
@@ -17,6 +17,7 @@ type APIV1UserHandler interface {
 	IndexByUsername(ctx *gin.Context)
 	IndexFriends(ctx *gin.Context)
 	Show(ctx *gin.Context)
+	ShowInternal(ctx *gin.Context)
 	ShowProfile(ctx *gin.Context)
 	Create(ctx *gin.Context)
 	UpdateProfile(ctx *gin.Context)
@@ -65,7 +66,6 @@ func (uh *apiV1UserHandler) IndexByUsername(ctx *gin.Context) {
 			Username:     u.Username,
 			Email:        u.Email,
 			ThumbnailURL: u.ThumbnailURL,
-			GroupIDs:     u.GroupIDs,
 		}
 
 		res.Users = append(res.Users, ur)
@@ -92,7 +92,6 @@ func (uh *apiV1UserHandler) IndexFriends(ctx *gin.Context) {
 			Username:     u.Username,
 			Email:        u.Email,
 			ThumbnailURL: u.ThumbnailURL,
-			GroupIDs:     u.GroupIDs,
 		}
 
 		res.Users[i] = ur
@@ -117,7 +116,31 @@ func (uh *apiV1UserHandler) Show(ctx *gin.Context) {
 		Username:     u.Username,
 		Email:        u.Email,
 		ThumbnailURL: u.ThumbnailURL,
+	}
+
+	ctx.JSON(http.StatusOK, res)
+}
+
+func (uh *apiV1UserHandler) ShowInternal(ctx *gin.Context) {
+	userID := ctx.Params.ByName("userID")
+
+	c := middleware.GinContextToContext(ctx)
+	u, err := uh.userApplication.Show(c, userID)
+	if err != nil {
+		handler.ErrorHandling(ctx, err)
+		return
+	}
+
+	res := &response.ShowUserInternal{
+		ID:           u.ID,
+		Name:         u.Name,
+		Username:     u.Username,
+		Email:        u.Email,
+		ThumbnailURL: u.ThumbnailURL,
 		GroupIDs:     u.GroupIDs,
+		FriendIDs:    u.FriendIDs,
+		CreatedAt:    u.CreatedAt,
+		UpdatedAt:    u.UpdatedAt,
 	}
 
 	ctx.JSON(http.StatusOK, res)

--- a/docs/12_backend/21_swagger/apiv1.yaml
+++ b/docs/12_backend/21_swagger/apiv1.yaml
@@ -484,7 +484,7 @@ components:
                   format: uuid
               friendIds:
                 type: array
-                description: 友達ユーザーID一覧
+                description: 友達ID一覧
                 items:
                   type: string
                   format: uuid
@@ -526,13 +526,6 @@ components:
                     thumbnail:
                       type: string
                       description: サムネイルURL
-                    groupIds:
-                      type: array
-                      description: グループID一覧
-                      items:
-                        type: string
-                        format: uuid
-
 
     ShowUser:
       description: ユーザー情報取得APIのレスポンス
@@ -558,12 +551,6 @@ components:
               thumbnail:
                 type: string
                 description: サムネイルURL
-              groupIds:
-                type: array
-                description: グループID一覧
-                items:
-                  type: string
-                  format: uuid
 
     CreateUser:
       description: ユーザー登録APIのレスポンス
@@ -597,7 +584,7 @@ components:
                   format: uuid
               friendIds:
                 type: array
-                description: 友達ユーザーID一覧
+                description: 友達ID一覧
                 items:
                   type: string
                   format: uuid
@@ -642,7 +629,7 @@ components:
                   format: uuid
               friendIds:
                 type: array
-                description: 友達ユーザーID一覧
+                description: 友達ID一覧
                 items:
                   type: string
                   format: uuid
@@ -687,7 +674,7 @@ components:
                   format: uuid
               friendIds:
                 type: array
-                description: 友達ユーザーID一覧
+                description: 友達ID一覧
                 items:
                   type: string
                   format: uuid

--- a/docs/12_backend/21_swagger/internal.yaml
+++ b/docs/12_backend/21_swagger/internal.yaml
@@ -12,6 +12,29 @@ servers:
     description: 開発環境
 
 paths:
+  /users/{userId}:
+    get:
+      summary: ユーザー情報取得
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: userId
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: ユーザーUUID
+      responses:
+        '200':
+          $ref: '#/components/responses/ShowUser'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/Unkown'
+
   /users/{userId}/groups/{groupId}:
     post:
       summary: ユーザー グループ追加
@@ -146,6 +169,51 @@ components:
           schema:
             type: object
 
+    ShowProfile:
+      description: 認証情報取得APIのレスポンス
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+                description: ユーザーID
+              name:
+                type: string
+                description: 表示名
+              username:
+                type: string
+                description: ユーザー名
+              email:
+                type: string
+                format: email
+                description: メールアドレス
+              thumbnail:
+                type: string
+                description: サムネイルURL
+              groupIds:
+                type: array
+                description: グループID一覧
+                items:
+                  type: string
+                  format: uuid
+              friendIds:
+                type: array
+                description: 友達ID一覧
+                items:
+                  type: string
+                  format: uuid
+              createdAt:
+                type: string
+                format: date-time
+                description: 作成日時
+              updatedAt:
+                type: string
+                format: date-time
+                description: 更新日時
+
     AddGroupUser:
       description: ユーザー グループ追加APIのレスポンス
       content:
@@ -175,6 +243,12 @@ components:
                 description: グループID一覧
                 items:
                   type: string
+              friendIds:
+                type: array
+                description: 友達ID一覧
+                items:
+                  type: string
+                  format: uuid
               createdAt:
                 type: string
                 format: date-time
@@ -211,6 +285,12 @@ components:
               groupIds:
                 type: array
                 description: グループID一覧
+                items:
+                  type: string
+                  format: uuid
+              friendIds:
+                type: array
+                description: 友達ID一覧
                 items:
                   type: string
                   format: uuid


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
* ユーザー情報取得APIのエンドポイントを内部用、外部用それぞれに分割

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
