### PR TITLE
通信成功時にはToastを出さないようにしたのと、無駄なコード直した

### DIFF
--- a/native/android/app/src/main/java/work/calmato/prestopay/ui/addFriend/AddFriendFragment.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/ui/addFriend/AddFriendFragment.kt
@@ -88,7 +88,7 @@ class AddFriendFragment : Fragment() {
         builder.setTitle(resources.getString(R.string.add_friend_question))
           ?.setPositiveButton(resources.getString(R.string.add)
           ) { _, _ ->
-            viewModel.addFriendApi(userProperty, requireActivity())
+            viewModel.addFriendApi(userProperty)
           }
           ?.setNegativeButton(resources.getString(R.string.cancel), null)
           ?.setView(R.layout.dialog_add_friend)

--- a/native/android/app/src/main/java/work/calmato/prestopay/ui/createGroup/CreateGroupFragment.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/ui/createGroup/CreateGroupFragment.kt
@@ -76,7 +76,7 @@ class CreateGroupFragment : PermissionBase() {
       if (usersListToBeSent!!.users.size in 0..64) {
         val groupProperty =
           CreateGroupProperty(groupName, thumbnailStr, usersListToBeSent!!.users.map { it.id })
-        viewModel.createGroupApi(groupProperty, requireActivity())
+        viewModel.createGroupApi(groupProperty)
       } else {
         Toast.makeText(
           requireContext(),

--- a/native/android/app/src/main/java/work/calmato/prestopay/ui/groupDetail/GroupDetailFragment.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/ui/groupDetail/GroupDetailFragment.kt
@@ -205,8 +205,7 @@ class GroupDetailFragment : Fragment() {
                 ) {
                   Log.d(ViewModelGroup.TAG, response.body().toString())
                   viewModel.deletePayment(
-                    payments!![viewHolder.adapterPosition].id,
-                    requireActivity()
+                    payments!![viewHolder.adapterPosition].id
                   )
                   frontView.visibility = ImageView.GONE
                   progressBar.visibility = android.widget.ProgressBar.INVISIBLE

--- a/native/android/app/src/main/java/work/calmato/prestopay/ui/groupFriend/GroupFriendFragment.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/ui/groupFriend/GroupFriendFragment.kt
@@ -208,8 +208,7 @@ class GroupFriendFragment : Fragment() {
                 ) {
                   Log.d(ViewModelGroup.TAG, response.body().toString())
                   viewModel.deleteGroup(
-                    groups!![viewHolder.adapterPosition].id,
-                    requireActivity()
+                    groups!![viewHolder.adapterPosition].id
                   )
                   frontView.visibility = ImageView.GONE
                   progressBar.visibility = android.widget.ProgressBar.INVISIBLE
@@ -308,8 +307,7 @@ class GroupFriendFragment : Fragment() {
                 ) {
                   Log.d(ViewModelGroup.TAG, response.body().toString())
                   viewModel.deleteFriendSwipe(
-                    friends!![viewHolder.adapterPosition].id,
-                    requireActivity()
+                    friends!![viewHolder.adapterPosition].id
                   )
                   frontView.visibility = ImageView.GONE
                   progressBar.visibility = android.widget.ProgressBar.INVISIBLE

--- a/native/android/app/src/main/java/work/calmato/prestopay/ui/login/LoginFragment.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/ui/login/LoginFragment.kt
@@ -331,7 +331,7 @@ class LoginFragment : Fragment() {
       val registerDeviceIdProperty = RegisterDeviceIdProperty(instanceId)
 
       // send instance_id to api
-      viewModel.registerDeviceId(registerDeviceIdProperty, requireActivity())
+      viewModel.registerDeviceId(registerDeviceIdProperty)
     })
   }
 

--- a/native/android/app/src/main/java/work/calmato/prestopay/ui/paymentDetail/PaymentDetailFragment.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/ui/paymentDetail/PaymentDetailFragment.kt
@@ -90,10 +90,7 @@ class PaymentDetailFragment : PermissionBase() {
           call: Call<Unit>,
           response: Response<Unit>
         ) {
-          if (response.isSuccessful) {
-            Toast.makeText(requireContext(), "精算登録しました", Toast.LENGTH_LONG).show()
-            requireActivity().onBackPressed()
-          } else {
+          if (!response.isSuccessful) {
             Toast.makeText(requireContext(), "精算登録に失敗しました", Toast.LENGTH_LONG).show()
           }
           progressBarPaymentDetail.visibility = ProgressBar.GONE

--- a/native/android/app/src/main/java/work/calmato/prestopay/ui/resetPassLogin/UpdatePassLoginFragment.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/ui/resetPassLogin/UpdatePassLoginFragment.kt
@@ -94,11 +94,6 @@ class UpdatePassLoginFragment : Fragment() {
             if (it.isSuccessful) {
               user.updatePassword(newPass).addOnCompleteListener {
                 if (it.isSuccessful) {
-                  Toast.makeText(
-                    requireContext(),
-                    resources.getString(R.string.password_changed),
-                    Toast.LENGTH_SHORT
-                  ).show()
                   this.findNavController().navigate(
                     UpdatePassLoginFragmentDirections.actionUpdatePassLoginFragmentToAccountHome()
                   )

--- a/native/android/app/src/main/java/work/calmato/prestopay/util/ViewModelFriendGroup.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/util/ViewModelFriendGroup.kt
@@ -1,6 +1,5 @@
 package work.calmato.prestopay.util
 
-import android.app.Activity
 import android.app.Application
 import android.util.Log
 import android.widget.Toast
@@ -121,31 +120,26 @@ class ViewModelFriendGroup(application: Application) : AndroidViewModel(applicat
     viewModelJob.cancel()
   }
 
-  fun addFriendApi(userProperty: UserProperty, activity: Activity) {
+  fun addFriendApi(userProperty: UserProperty) {
     _nowLoading.value = true
     val userId = userProperty.id
     viewModelScope.launch {
       try {
         friendsRepository.addFriend(id!!, UserId(userId), userProperty)
-        Toast.makeText(
-          activity,
-          getApplication<Application>().resources.getString(R.string.add_friend_succeeded),
-          Toast.LENGTH_SHORT
-        ).show()
         _nowLoading.value = false
       } catch (e: java.lang.Exception) {
-        Toast.makeText(activity, e.message, Toast.LENGTH_LONG).show()
+        Toast.makeText(getApplication(), e.message, Toast.LENGTH_LONG).show()
         _nowLoading.value = false
       }
     }
   }
 
-  fun createGroupApi(groupProperty: CreateGroupProperty, activity: Activity) {
+  fun createGroupApi(groupProperty: CreateGroupProperty) {
     _nowLoading.value = true
     Api.retrofitService.createGroup("Bearer $id", groupProperty)
       .enqueue(object : Callback<GroupPropertyResponse> {
         override fun onFailure(call: Call<GroupPropertyResponse>, t: Throwable) {
-          Toast.makeText(activity, t.message, Toast.LENGTH_LONG).show()
+          Toast.makeText(getApplication(), t.message, Toast.LENGTH_LONG).show()
           _nowLoading.value = false
         }
 
@@ -165,15 +159,10 @@ class ViewModelFriendGroup(application: Application) : AndroidViewModel(applicat
                 userIds = responseGroup.userIds
               ))
             }
-            Toast.makeText(
-              activity,
-              getApplication<Application>().resources.getString(R.string.create_group_succeeded),
-              Toast.LENGTH_SHORT
-            ).show()
             _navigateToHome.value = true
           } else {
             Toast.makeText(
-              activity,
+              getApplication(),
               getApplication<Application>().resources.getString(R.string.create_group_failed),
               Toast.LENGTH_LONG
             ).show()
@@ -183,7 +172,7 @@ class ViewModelFriendGroup(application: Application) : AndroidViewModel(applicat
       })
   }
 
-  fun deleteFriendSwipe(friendId: String, activity: Activity) {
+  fun deleteFriendSwipe(friendId: String) {
     _nowLoading.value = true
 
     coroutineScope.launch {
@@ -193,7 +182,7 @@ class ViewModelFriendGroup(application: Application) : AndroidViewModel(applicat
         }
       } catch (e: java.lang.Exception) {
         Toast.makeText(
-          activity,
+          getApplication(),
           getApplication<Application>().resources.getString(R.string.delete_friend_failed),
           Toast.LENGTH_LONG
         ).show()
@@ -203,7 +192,7 @@ class ViewModelFriendGroup(application: Application) : AndroidViewModel(applicat
     _nowLoading.value = false
   }
 
-  fun deleteGroup(groupId: String, activity: Activity) {
+  fun deleteGroup(groupId: String) {
     _nowLoading.value = true
 
     coroutineScope.launch {
@@ -213,7 +202,7 @@ class ViewModelFriendGroup(application: Application) : AndroidViewModel(applicat
         }
       } catch (e: java.lang.Exception) {
         Toast.makeText(
-          activity,
+          getApplication(),
           getApplication<Application>().resources.getString(R.string.delete_group_failed),
           Toast.LENGTH_LONG
         ).show()

--- a/native/android/app/src/main/java/work/calmato/prestopay/util/ViewModelPayment.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/util/ViewModelPayment.kt
@@ -1,6 +1,5 @@
 package work.calmato.prestopay.util
 
-import android.app.Activity
 import android.app.Application
 import android.util.Log
 import android.widget.Toast
@@ -60,7 +59,7 @@ class ViewModelPayment(application: Application) : AndroidViewModel(application)
     }
   }
 
-  fun deletePayment(paymentId: String, activity: Activity) {
+  fun deletePayment(paymentId: String) {
     _nowLoading.value = true
 
     coroutineScope.launch {
@@ -70,7 +69,7 @@ class ViewModelPayment(application: Application) : AndroidViewModel(application)
         }
       } catch (e: java.lang.Exception) {
         Toast.makeText(
-          activity,
+          getApplication(),
           getApplication<Application>().resources.getString(R.string.delete_friend_failed),
           Toast.LENGTH_LONG
         ).show()

--- a/native/android/app/src/main/java/work/calmato/prestopay/util/ViewModelUser.kt
+++ b/native/android/app/src/main/java/work/calmato/prestopay/util/ViewModelUser.kt
@@ -1,6 +1,5 @@
 package work.calmato.prestopay.util
 
-import android.app.Activity
 import android.app.Application
 import android.util.Log
 import android.widget.Toast
@@ -15,14 +14,14 @@ class ViewModelUser(application: Application) : AndroidViewModel(application) {
   private val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getApplication())
 
 
-  fun registerDeviceId(registerDeviceIdProperty: RegisterDeviceIdProperty, activity: Activity) {
+  fun registerDeviceId(registerDeviceIdProperty: RegisterDeviceIdProperty) {
     val id = sharedPreferences.getString("token", null)
     val token = "Bearer $id"
     Api.retrofitService
       .registerDeviceId(token, registerDeviceIdProperty)
       .enqueue(object : Callback<AccountResponse> {
         override fun onFailure(call: Call<AccountResponse>, t: Throwable) {
-          Toast.makeText(activity, t.message, Toast.LENGTH_LONG).show()
+          Toast.makeText(getApplication(), t.message, Toast.LENGTH_LONG).show()
         }
 
         override fun onResponse(call: Call<AccountResponse>, response: Response<AccountResponse>) {


### PR DESCRIPTION
## やったこと

- ユーザーにとっては通信成功は当たり前なのでToast出さないで画面遷移する

- ViewModelからToast出すときに渡すContextは、引数なしでもgetApplicationが使えたのでそれにした

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
