### PR TITLE
修正箇所#11

### DIFF
--- a/api/calc/internal/application/payment.go
+++ b/api/calc/internal/application/payment.go
@@ -89,6 +89,11 @@ func (pa *paymentApplication) Index(
 	// ユーザー毎の支払額合計作成
 	pys := map[string]*payment.Payer{}
 	for _, p := range ps {
+		// 未支払いのもののみ取得
+		if p.IsCompleted {
+			continue
+		}
+
 		// 支払い情報に登録されている通貨情報を取得
 		currentRate := ers.Rates[p.Currency]
 		if currentRate == 0 {


### PR DESCRIPTION
## 指摘内容

```
グループとしての各ユーザーが払った額のプラスマイナス返す(usersに入ってる)時に、完了している支払いも考慮されて計算されちゃってるのが11です！
```

## 修正箇所

> /groups/{groupId}/payments

レスポンス users について、支払いが完了 (isCompleted == true) のものについては含めないように変更

```:go
		// 未支払いのもののみ取得
		if p.IsCompleted {
			continue
		}
```