### PR TITLE
fix: 通貨計算がうまくできてなかったところを修正

### DIFF
--- a/api/calc/internal/application/payment.go
+++ b/api/calc/internal/application/payment.go
@@ -76,7 +76,7 @@ func (pa *paymentApplication) Index(
 		return nil, nil, "", err
 	}
 
-	// 為替レート一覧のmapを作成
+	// 為替レート一覧のmapを作成 -> KeyはUpperケースでくる
 	ers, err := pa.exchangeService.Index(ctx)
 	if err != nil {
 		return nil, nil, "", err
@@ -96,7 +96,8 @@ func (pa *paymentApplication) Index(
 		}
 
 		// 支払い情報に登録されている通貨情報を取得
-		currentRate := ers.Rates[p.Currency]
+		pc := strings.ToUpper(p.Currency)
+		currentRate := ers.Rates[pc]
 		if currentRate == 0 {
 			currentRate = ers.Rates[ers.Base]
 		}
@@ -127,7 +128,7 @@ func (pa *paymentApplication) Index(
 		}
 	}
 
-	return ps, pys, currency, err
+	return ps, pys, strings.ToLower(currency), err
 }
 
 func (pa *paymentApplication) Create(


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
* 内部APIと外部APIで以下のように違いがあったため、計算がうまくできてなかった
  * 内部API: 通貨については全て小文字(Lower Case)で記述 -> e.g.) jpy
  * 外部API: 通貨については全て大文字(Upper Case)で記述 -> e.g.) JPY

* いったん、計算時は大文字, レスポンスは小文字にすることで修正
  * -> 外部APIのレスポンスが替わった際はそのとき検討する

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

<!-- 次のプルリクにまわす実装内容を書く -->

## 備考

<!-- マージ後に必要な操作などがあればここに -->
